### PR TITLE
Add reusable fleet helpers and document CLI

### DIFF
--- a/BATTLE_SIM.py
+++ b/BATTLE_SIM.py
@@ -1,0 +1,195 @@
+# Battle Simulator for Pyodide and CLI
+# Implements battle phases using dataclasses defined in models.py
+# Runs headless with optional CLI arguments.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+from typing import List
+
+from models import Ship
+from fleet_setup import demo_fleets
+
+try:
+    import rolldice  # type: ignore
+except Exception:  # rolldice may not be installed in Pyodide yet
+    rolldice = None  # will be loaded dynamically
+
+BATTLE_ORDERS = [
+    "Brace for Impact",
+    "Lock On",
+    "All Power to Shields",
+    "Reload Ordnance",
+    "Boarding Party",
+    "Fire Everything",
+]
+
+
+async def install_dependencies() -> None:
+    """Install runtime packages when running in Pyodide."""
+    global rolldice
+    if rolldice is not None:
+        return
+    try:
+        import micropip  # type: ignore
+    except Exception:
+        return
+    await micropip.install("py-rolldice")
+    import rolldice as _rolldice  # type: ignore
+
+    rolldice = _rolldice
+
+
+# ---------------- Battle Phases -----------------
+
+
+def select_orders(fleet: List[Ship]) -> None:
+    """Randomly assign orders to each ship."""
+    for ship in fleet:
+        ship.order = random.choice(BATTLE_ORDERS)
+        print(f"{ship.name} selects order: {ship.order}")
+
+
+def resolve_hazards(fleet: List[Ship]) -> None:
+    """Randomly apply environmental hazards."""
+    for ship in fleet:
+        if not ship.systems:
+            continue
+        if random.random() < 0.1:  # 10% chance a system takes damage
+            system_name = random.choice(list(ship.systems.keys()))
+            ship.systems[system_name].damage(10)
+            print(
+                f"Hazard damages {ship.name}'s {system_name}, now {ship.systems[system_name].efficiency}%"
+            )
+
+
+def shooting_phase(attacking: List[Ship], defending: List[Ship]) -> None:
+    """Resolve shooting between fleets."""
+    if rolldice is None:
+        raise RuntimeError("rolldice not loaded")
+    for ship in attacking:
+        targets = [t for t in defending if t.hull > 0]
+        if not targets or ship.hull <= 0:
+            continue
+        target = random.choice(targets)
+        roll, _ = rolldice.roll_dice("2d20")
+        if roll > target.shield:
+            dmg, _ = rolldice.roll_dice("2d6")
+            target.hull = max(0, target.hull - int(dmg))
+            print(f"{ship.name} hits {target.name} for {dmg} (hull {target.hull})")
+            if target.hull == 0:
+                print(f"{target.name} destroyed!")
+        else:
+            print(f"{ship.name} misses {target.name}")
+
+
+def missile_phase(attacking: List[Ship], defending: List[Ship]) -> None:
+    """Fire missiles if available."""
+    if rolldice is None:
+        raise RuntimeError("rolldice not loaded")
+    for ship in attacking:
+        if ship.weapons.missiles <= 0 or ship.hull <= 0:
+            continue
+        targets = [t for t in defending if t.hull > 0]
+        if not targets:
+            continue
+        target = random.choice(targets)
+        ship.weapons.missiles -= 1
+        dmg, _ = rolldice.roll_dice("3d6")
+        target.hull = max(0, target.hull - int(dmg))
+        print(
+            f"{ship.name} launches missile at {target.name} for {dmg} (hull {target.hull})"
+        )
+        if target.hull == 0:
+            print(f"{target.name} destroyed by missile!")
+
+
+def boarding_phase(attacking: List[Ship], defending: List[Ship]) -> None:
+    """Attempt boarding actions."""
+    if rolldice is None:
+        raise RuntimeError("rolldice not loaded")
+    for ship in attacking:
+        if ship.hull <= 0:
+            continue
+        if random.random() < 0.2:  # 20% chance to board
+            targets = [t for t in defending if t.hull > 0]
+            if not targets:
+                continue
+            target = random.choice(targets)
+            atk, _ = rolldice.roll_dice("1d20")
+            if atk + ship.boarding_strength > target.boarding_strength:
+                dmg, _ = rolldice.roll_dice("1d10")
+                target.hull = max(0, target.hull - int(dmg))
+                print(
+                    f"{ship.name} boards {target.name} for {dmg} damage (hull {target.hull})"
+                )
+                if target.hull == 0:
+                    print(f"{target.name} captured and destroyed!")
+            else:
+                print(f"{ship.name} fails to board {target.name}")
+
+
+def repair_phase(fleet: List[Ship]) -> None:
+    """Attempt simple repairs on damaged systems."""
+    if rolldice is None:
+        raise RuntimeError("rolldice not loaded")
+    for ship in fleet:
+        damaged = [s for s in ship.systems.values() if s.status != "Operational"]
+        if damaged and random.random() < 0.5:
+            system = random.choice(damaged)
+            system.repair(10)
+            print(
+                f"{ship.name} repairs {system.effect or 'a system'} to {system.efficiency}%"
+            )
+
+
+# --------------- Simulation Runner ---------------
+
+
+def run_round(fleet_a: List[Ship], fleet_b: List[Ship], round_num: int) -> None:
+    print(f"\n=== ROUND {round_num} ===")
+    select_orders(fleet_a + fleet_b)
+    resolve_hazards(fleet_a + fleet_b)
+    shooting_phase(fleet_a, fleet_b)
+    shooting_phase(fleet_b, fleet_a)
+    missile_phase(fleet_a, fleet_b)
+    missile_phase(fleet_b, fleet_a)
+    boarding_phase(fleet_a, fleet_b)
+    boarding_phase(fleet_b, fleet_a)
+    repair_phase(fleet_a + fleet_b)
+
+
+def battle(fleet_a: List[Ship], fleet_b: List[Ship], rounds: int = 3) -> None:
+    for rnd in range(1, rounds + 1):
+        if not fleet_a or not fleet_b:
+            break
+        run_round(fleet_a, fleet_b, rnd)
+        fleet_a = [s for s in fleet_a if s.hull > 0]
+        fleet_b = [s for s in fleet_b if s.hull > 0]
+        if not fleet_a or not fleet_b:
+            break
+    print("\n--- Battle Over ---")
+    for ship in fleet_a + fleet_b:
+        status = "DESTROYED" if ship.hull <= 0 else f"Hull {ship.hull}"
+        print(f"{ship.name}: {status}")
+
+
+async def main_async(rounds: int) -> None:
+    await install_dependencies()
+    fleet_a, fleet_b = demo_fleets()
+    battle(fleet_a, fleet_b, rounds)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a simple fleet battle simulation")
+    parser.add_argument(
+        "--rounds", type=int, default=3, help="Number of rounds to simulate"
+    )
+    args = parser.parse_args()
+    asyncio.run(main_async(args.rounds))
+
+
+if __name__ == "__main__":
+    main()

--- a/DESIGN_CANVAS.md
+++ b/DESIGN_CANVAS.md
@@ -55,7 +55,7 @@ sample code continues to function while using the dataclasses.
 
 ## Usage Pattern
 
-The helper `new_ship` function in the sample interface instantiates `Ship` objects with pre-populated systems. Systems are created using `system_status_block`, which now returns a `ShipSystem` dataclass.
+Utility helpers in `fleet_setup.py` provide `system_block` and `new_ship` functions. They are used by both the CLI simulator and the sample interface to build demo fleets.
 
 These dataclasses replace the previous raw dictionaries, providing clearer
 structure for future expansion while remaining lightweight for Pyodide.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ pip install -r requirements.txt
 poetry install
 ```
 
+### Running the Simulator
+
+After installing dependencies you can run the command line simulator:
+
+```sh
+python BATTLE_SIM.py --rounds 3
+```
+
+This will install `py-rolldice` via `micropip` when executed in Pyodide or use
+your local installation when running on the desktop.
+
 ---
 
 ## Requirements

--- a/fleet_setup.py
+++ b/fleet_setup.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from models import Ship, ShipSystem, WeaponSystem, WeaponBattery
+
+
+def system_block(eff: int = 100, thresh: int = 50, effect: str = "") -> ShipSystem:
+    """Create a ShipSystem instance with common defaults."""
+    return ShipSystem(efficiency=eff, critical_threshold=thresh, effect=effect)
+
+
+def new_ship(
+    name: str,
+    class_name: str,
+    hull: int,
+    shield: int,
+    weapons: WeaponSystem,
+    missiles: int,
+    crew: int,
+    leadership: int,
+    boarding_strength: int,
+    speed: int,
+    maneuver: int,
+    systems: dict[str, ShipSystem],
+    ai: str,
+) -> Ship:
+    """Instantiate a Ship dataclass with supplied parameters."""
+    weapons.missiles = missiles
+    return Ship(
+        name=name,
+        hull=hull,
+        shield=shield,
+        weapons=weapons,
+        crew=crew,
+        leadership=leadership,
+        boarding_strength=boarding_strength,
+        speed=speed,
+        maneuver=maneuver,
+        systems=systems,
+        ai=ai,
+        class_name=class_name,
+    )
+
+
+def demo_fleets() -> tuple[list[Ship], list[Ship]]:
+    """Return two small demo fleets used by the CLI and HTML sample."""
+    aurora_weapons = WeaponSystem(
+        [
+            WeaponBattery(
+                "Lance Battery", rating=3, accuracy=1, damage_dice="2d6", range="long"
+            ),
+            WeaponBattery("Macro Cannon", rating=2, accuracy=0, damage_dice="3d6"),
+        ],
+        missiles=4,
+    )
+
+    aurora = new_ship(
+        "Aurora Huntress",
+        "Light Cruiser",
+        80,
+        65,
+        aurora_weapons,
+        4,
+        2,
+        7,
+        1,
+        25,
+        2,
+        {
+            "engines": system_block(85, effect="Speed halved when offline"),
+            "shields": system_block(70, effect="Hull exposed"),
+            "targeting": system_block(90, effect="Attack penalty"),
+        },
+        "Efficient and sarcastic",
+    )
+
+    warden_weapons = WeaponSystem(
+        [
+            WeaponBattery(
+                "Plasma Broadside",
+                rating=4,
+                accuracy=-1,
+                damage_dice="4d6",
+                range="long",
+                special="area",
+            ),
+        ],
+        missiles=6,
+    )
+
+    warden = new_ship(
+        "Celestial Warden",
+        "Battleship",
+        100,
+        80,
+        warden_weapons,
+        6,
+        4,
+        9,
+        3,
+        18,
+        1,
+        {
+            "engines": system_block(90, effect="Ship immobilised"),
+            "shields": system_block(80, effect="Hull exposed"),
+            "reactor": system_block(100, effect="Catastrophic explosion on failure"),
+        },
+        "Formal and calculating",
+    )
+
+    return [aurora], [warden]

--- a/sample_interface.html
+++ b/sample_interface.html
@@ -3,29 +3,8 @@
 <body>
 <pre id="output"></pre>
 <script type="text/python">
-from models import Ship, ShipSystem, WeaponSystem, WeaponBattery
-
-
-def system_block(eff=100, thresh=50, effect=""):
-    return ShipSystem(efficiency=eff, critical_threshold=thresh, effect=effect)
-
-
-def new_ship(name, class_name, hull, shield, weapons, missiles, crew,
-             leadership, boarding_strength, speed, maneuver, systems, ai):
-    return Ship(
-        name=name,
-        hull=hull,
-        shield=shield,
-        weapons=weapons,
-        crew=crew,
-        leadership=leadership,
-        boarding_strength=boarding_strength,
-        speed=speed,
-        maneuver=maneuver,
-        systems=systems,
-        ai=ai,
-        class_name=class_name,
-    )
+from models import Ship, WeaponSystem, WeaponBattery
+from fleet_setup import system_block, new_ship
 
 # -- Example fleet with varied weapons and systems --
 aurora_weapons = WeaponSystem([


### PR DESCRIPTION
## Summary
- extract reusable fleet helpers into `fleet_setup.py`
- reuse helpers from battle simulator and sample interface
- document CLI simulator in the README
- mention helper module in DESIGN_CANVAS

## Testing
- `python -m py_compile BATTLE_SIM.py fleet_setup.py`
- `pytest -q`
- `python BATTLE_SIM.py --rounds 1`

------
https://chatgpt.com/codex/tasks/task_e_68890f0fdf948331ae42944e6babab02