### PR TITLE
Add 3D orientation and arcs

### DIFF
--- a/DESIGN_CANVAS.md
+++ b/DESIGN_CANVAS.md
@@ -46,6 +46,12 @@ Key fields:
 - `crew`, `leadership`, `boarding_strength`
 - `class_name`: high level ship classification (frigate, cruiser, etc.)
 - `speed`, `maneuver`: basic movement traits
+- `x`, `y`, `z`: positional coordinates for future targeting logic
+- `heading`: yaw orientation in degrees
+- `pitch`: vertical orientation in degrees
+- Ships advance each round using `speed`, `heading`, and `pitch`
+- Targeting prioritizes the nearest enemy ship using 3D distance
+- Weapon arcs (fore/aft/port/starboard/dorsal/ventral) and range bands gate ballistic fire
 - `systems`: mapping of system names to `ShipSystem`
 - `ai`: description or personality string used for flavour text
 - `order` and `range`: current tactical order and range band

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ An extensible, web-friendly, fully automated fleet battle simulator inspired by 
 * System degradation, critical hits, and repair attempts
 * Fully compatible with browser/Jupyter/Pyodide (no blocking I/O)
 * Example code for both procedural and OOP usage
+* Basic positional data (x, y, z) plus heading and pitch for each ship
+* Movement each round based on speed, heading, and pitch with nearest-target selection
+* Weapon arcs include dorsal/ventral angles and respect range bands
 
 ---
 

--- a/fleet_setup.py
+++ b/fleet_setup.py
@@ -21,6 +21,11 @@ def new_ship(
     maneuver: int,
     systems: dict[str, ShipSystem],
     ai: str,
+    x: float = 0.0,
+    y: float = 0.0,
+    z: float = 0.0,
+    heading: float = 0.0,
+    pitch: float = 0.0,
 ) -> Ship:
     """Instantiate a Ship dataclass with supplied parameters."""
     weapons.missiles = missiles
@@ -36,6 +41,11 @@ def new_ship(
         maneuver=maneuver,
         systems=systems,
         ai=ai,
+        x=x,
+        y=y,
+        z=z,
+        heading=heading,
+        pitch=pitch,
         class_name=class_name,
     )
 
@@ -70,6 +80,11 @@ def demo_fleets() -> tuple[list[Ship], list[Ship]]:
             "targeting": system_block(90, effect="Attack penalty"),
         },
         "Efficient and sarcastic",
+        x=-10.0,
+        y=0.0,
+        z=0.0,
+        heading=90.0,
+        pitch=0.0,
     )
 
     warden_weapons = WeaponSystem(
@@ -104,6 +119,11 @@ def demo_fleets() -> tuple[list[Ship], list[Ship]]:
             "reactor": system_block(100, effect="Catastrophic explosion on failure"),
         },
         "Formal and calculating",
+        x=10.0,
+        y=0.0,
+        z=0.0,
+        heading=270.0,
+        pitch=0.0,
     )
 
     return [aurora], [warden]

--- a/models.py
+++ b/models.py
@@ -71,6 +71,11 @@ class Ship:
     boarding_strength: int
     class_name: str = "Frigate"
     speed: int = 20
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    heading: float = 0.0
+    pitch: float = 0.0
     maneuver: int = 1
     systems: Dict[str, ShipSystem] = field(default_factory=dict)
     ai: str = ""

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from BATTLE_SIM import distance, move_fleet, in_arc, in_range, can_fire
+from fleet_setup import new_ship
+from models import WeaponSystem, WeaponBattery
+
+
+def dummy_ship(name, x=0.0, y=0.0, z=0.0, heading=0.0, pitch=0.0):
+    return new_ship(
+        name,
+        "Frigate",
+        hull=10,
+        shield=5,
+        weapons=WeaponSystem([WeaponBattery("Gun", rating=1, damage_dice="1d1")]),
+        missiles=0,
+        crew=1,
+        leadership=1,
+        boarding_strength=1,
+        speed=10,
+        maneuver=1,
+        systems={},
+        ai="",
+        x=x,
+        y=y,
+        z=z,
+        heading=heading,
+        pitch=pitch,
+    )
+
+
+def test_move_and_distance():
+    ship = dummy_ship("A")
+    move_fleet([ship])
+    assert ship.x == 10 and ship.y == 0 and ship.z == 0
+    target = dummy_ship("B", x=10)
+    assert distance(ship, target) == 0
+
+
+def test_arc_and_range():
+    ship = dummy_ship("A", heading=0)
+    target = dummy_ship("T", x=5, y=0)
+    battery = ship.weapons.batteries[0]
+    assert in_arc(ship, target, battery.arc)
+    assert in_range(ship, target, battery.range)
+    assert can_fire(ship, target, battery)
+    other = dummy_ship("O", x=-5, y=0)
+    assert not in_arc(ship, other, battery.arc)
+
+
+def test_dorsal_ventral_arcs():
+    ship = dummy_ship("A", heading=0, pitch=0)
+    above = dummy_ship("Up", z=5)
+    below = dummy_ship("Down", z=-5)
+    assert in_arc(ship, above, "dorsal")
+    assert not in_arc(ship, above, "ventral")
+    assert in_arc(ship, below, "ventral")
+    assert not in_arc(ship, below, "dorsal")


### PR DESCRIPTION
## Summary
- extend `Ship` dataclass with `pitch`
- implement yaw/pitch helpers and dorsal/ventral arcs
- move ships in 3D using heading and pitch
- update factory, docs, and demo fleet
- test new firing arc logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889bd1802c88331bd7ccb753881f33d