### PR TITLE
Add pytest configuration and battle tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ python BATTLE_SIM.py --rounds 3
 This will install `py-rolldice` via `micropip` when executed in Pyodide or use
 your local installation when running on the desktop.
 
+
+### Running Tests
+
+After installing the requirements, execute:
+
+```sh
+pytest
+```
+
 ### Browser Demo
 
 Open `battle.html` in a modern browser to see the simulation running in PyScript.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,13 @@ authors = ["Dave Carmocan <yakuzadave@gmail.com>"]
 python = "^3.10"
 py-rolldice = "*"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 py-rolldice
+pytest

--- a/tests/test_battle_phases.py
+++ b/tests/test_battle_phases.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from BATTLE_SIM import select_orders, shooting_phase, apply_hazard
+from fleet_setup import new_ship, system_block
+from models import WeaponSystem, WeaponBattery
+
+
+def dummy_ship(name):
+    return new_ship(
+        name,
+        "Frigate",
+        hull=10,
+        shield=5,
+        weapons=WeaponSystem([WeaponBattery("Gun", rating=1, damage_dice="1d6")]),
+        missiles=0,
+        crew=1,
+        leadership=1,
+        boarding_strength=1,
+        speed=10,
+        maneuver=1,
+        systems={"engines": system_block()},
+        ai="",
+    )
+
+
+def test_select_orders_seeded():
+    random.seed(1)
+    ships = [dummy_ship("A"), dummy_ship("B")]
+    select_orders(ships)
+    assert [s.order for s in ships] == ["All Power to Shields", "Run Silent"]
+
+
+def test_shooting_damage_seeded():
+    random.seed(2)
+    attacker = dummy_ship("Attacker")
+    defender = dummy_ship("Defender")
+    shooting_phase([attacker], [defender])
+    assert defender.hull == 10  # miss with this seed
+
+
+def test_apply_hazard_minefield_seeded():
+    random.seed(1)
+    ship = dummy_ship("Hazard")
+    apply_hazard(ship, "Minefield")
+    assert ship.hull == 8
+


### PR DESCRIPTION
## Summary
- configure pytest in `pyproject.toml` and `requirements.txt`
- add unit tests for orders, shooting, and hazards
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c326246083318a655041351d315c